### PR TITLE
ci: preview deployment for branches

### DIFF
--- a/.github/preview.yaml
+++ b/.github/preview.yaml
@@ -1,0 +1,28 @@
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install and Build
+        run: |
+          npm install
+          npm run build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./build/


### PR DESCRIPTION
This PR adds a GitHub Action that deploys the site for every pr (see https://github.com/marketplace/actions/deploy-pr-preview for details).