### PR TITLE
feat: minimal search engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "markdown-it": "^14.0.0",
         "markdown-it-katex": "^2.0.3",
         "match-sorter": "^6.3.1",
+        "minisearch": "^6.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.21.0",
@@ -5437,6 +5438,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.3.0.tgz",
+      "integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ=="
     },
     "node_modules/minizlib": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "markdown-it": "^14.0.0",
     "markdown-it-katex": "^2.0.3",
     "match-sorter": "^6.3.1",
+    "minisearch": "^6.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.0",

--- a/src/Gallery.tsx
+++ b/src/Gallery.tsx
@@ -7,18 +7,21 @@ export default function Gallery({ diagrams }: { diagrams: DiagramData[] }) {
       {diagrams.map((diagram) => {
         const previewURL = import.meta.env.BASE_URL + diagram.previewURI;
         return (
-          <Link to={`/diagrams/${diagram.id}`}>
+          <Link key={`link-to-${diagram.id}`} to={`/diagrams/${diagram.id}`}>
             <div
-              key={diagram.id}
+              key={`card-${diagram.id}`}
               className="rounded-md bg-white p-4 shadow-md hover:shadow-lg focus:ring"
             >
               <img
+                key={`preview-${diagram.id}`}
                 className="w-full h-60  object-center object-cover"
                 src={previewURL}
                 alt={diagram.title}
                 loading="lazy"
               />
-              <h2 className="font-bold text-black">{diagram.title}</h2>
+              <h2 key={`title-${diagram.id}`} className="font-bold text-black">
+                {diagram.title}
+              </h2>
             </div>
           </Link>
         );

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,13 +1,25 @@
+import React from "react";
 import Gallery from "./Gallery";
 import Header from "./Header";
 import Search from "./Search";
-import { diagrams } from "./main";
+import { allDiagrams, miniSearch } from "./main";
 
 function Home() {
+  const [diagrams, setDiagrams] = React.useState(allDiagrams);
   return (
     <div className="container mx-auto flex flex-col justify-center items-center m-8">
       <Header />
-      <Search />
+      <Search
+        index={miniSearch}
+        onFound={(res) => {
+          const indices = res.map(({ id }) => id);
+          // if no results, default to all
+          if (res.length === 0) setDiagrams(allDiagrams);
+          else {
+            setDiagrams(allDiagrams.filter(({ id }) => indices.includes(id)));
+          }
+        }}
+      />
       <Gallery diagrams={diagrams} />
     </div>
   );

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -16,7 +16,15 @@ function Home() {
           // if no results, default to all
           if (res.length === 0) setDiagrams(allDiagrams);
           else {
-            setDiagrams(allDiagrams.filter(({ id }) => indices.includes(id)));
+            const filtered = allDiagrams.filter(({ id }) =>
+              indices.includes(id)
+            );
+            const ranked = filtered.sort(
+              (a, b) =>
+                res.find(({ id }) => b.id === id)!.score -
+                res.find(({ id }) => a.id === id)!.score
+            );
+            setDiagrams(ranked);
           }
         }}
       />

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -2,6 +2,7 @@ import Minisearch from "minisearch"; // Import the Minisearch type using default
 
 export type Match = {
   id: number;
+  score: number;
 };
 
 export default function Search({
@@ -14,6 +15,7 @@ export default function Search({
   const search = (event: React.ChangeEvent<HTMLInputElement>) => {
     const res = index.search(event.target.value, { fuzzy: 0.2 });
     onFound(res);
+    console.log(res);
   };
 
   return (

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -1,106 +1,35 @@
-export default function Search() {
+import Minisearch from "minisearch"; // Import the Minisearch type using default import syntax
+
+export type Match = {
+  id: number;
+};
+
+export default function Search({
+  index,
+  onFound,
+}: {
+  index: Minisearch;
+  onFound: (result: Match[]) => void;
+}) {
+  const search = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const res = index.search(event.target.value, { fuzzy: 0.2 });
+    onFound(res);
+  };
+
   return (
-    <form className="w-full py-4">
+    <div className="w-full py-4">
       <div className="flex">
-        <label className="mb-2 text-sm font-medium text-gray-900 sr-only dark:text-white">
-          Your Email
-        </label>
-        <button
-          id="dropdown-button"
-          data-dropdown-toggle="dropdown"
-          className="flex-shrink-0 z-10 inline-flex items-center py-2.5 px-4 text-sm font-medium text-center text-gray-900 bg-gray-100 border border-gray-300 rounded-s-lg hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:focus:ring-gray-700 dark:text-white dark:border-gray-600"
-          type="button"
-        >
-          All domains{" "}
-          <svg
-            className="w-2.5 h-2.5 ms-2.5"
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 10 6"
-          >
-            <path
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="m1 1 4 4 4-4"
-            />
-          </svg>
-        </button>
-        <div
-          id="dropdown"
-          className="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700"
-        >
-          <ul
-            className="py-2 text-sm text-gray-700 dark:text-gray-200"
-            aria-labelledby="dropdown-button"
-          >
-            <li>
-              <button
-                type="button"
-                className="inline-flex w-full px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
-              >
-                Mockups
-              </button>
-            </li>
-            <li>
-              <button
-                type="button"
-                className="inline-flex w-full px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
-              >
-                Templates
-              </button>
-            </li>
-            <li>
-              <button
-                type="button"
-                className="inline-flex w-full px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
-              >
-                Design
-              </button>
-            </li>
-            <li>
-              <button
-                type="button"
-                className="inline-flex w-full px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
-              >
-                Logos
-              </button>
-            </li>
-          </ul>
-        </div>
         <div className="relative w-full">
           <input
             type="search"
             id="search-dropdown"
-            className="block p-2.5 w-full z-20 text-sm text-gray-900 bg-gray-50 rounded-e-lg border-s-gray-50 border-s-2 border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-s-gray-700  dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:border-blue-500"
-            placeholder=""
+            className="block p-2.5 w-full z-20 text-sm text-gray-900 bg-gray-50 rounded-lg border-s-gray-50 border-s-2 border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-s-gray-700  dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:border-blue-500"
+            placeholder="Start typing to search in title, notes, domain, or code"
+            onChange={search}
             required
           />
-          <button
-            type="submit"
-            className="absolute top-0 end-0 p-2.5 text-sm font-medium h-full text-white bg-blue-700 rounded-e-lg border border-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
-          >
-            <svg
-              className="w-4 h-4"
-              aria-hidden="true"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 20 20"
-            >
-              <path
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"
-              />
-            </svg>
-            <span className="sr-only">Search</span>
-          </button>
         </div>
       </div>
-    </form>
+    </div>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,16 +10,27 @@ import Home from "./Home";
 import Diagram from "./Diagram";
 import { DiagramData } from "./types";
 import NotFound from "./NotFound";
+import MiniSearch from "minisearch";
 
+// HACK: load the diagrams.json file from the public folder on startup and build a search index.
+// NOTE: in production, this should be done as a build step and the index should be loaded from a static file.
 const bundleURL = new URL("/diagrams/diagrams.json", import.meta.url).href;
-export const diagrams: DiagramData[] = await fetch(bundleURL).then((response) =>
-  response.json()
+export const allDiagrams: DiagramData[] = await fetch(bundleURL).then(
+  (response) => response.json()
 );
+export const miniSearch = new MiniSearch({
+  fields: ["title", "notes", "code", "author", "domains"], // fields to index for full-text search
+  storeFields: ["title", "id"], // fields to return with search results
+});
+
+// Index all documents
+miniSearch.addAll(allDiagrams);
+console.log(miniSearch.search("diagram"));
 
 const DiagramWrapper = () => {
   const { diagramID } = useParams();
 
-  const diagram = diagrams.find(({ id }) => id === parseInt(diagramID!))!;
+  const diagram = allDiagrams.find(({ id }) => id === parseInt(diagramID!))!;
 
   return <Diagram diagram={diagram} />;
 };


### PR DESCRIPTION
Resolves #16 

This PR adds a simple search engine using `minisearch`. which includes the following main steps and temporary hacks:

* Build a small index upon page load
* Hard-code a fuzzy search config of `0.2`, i.e. "a max edit distance of 0.2 * term length, rounded to nearest integer"
* Run search on text field change, i.e. every keystroke
* Filter the in-memory diagram data JSON by id and render the grid filtered by the id
* On empty search result, defaults to a full grid of all diagrams